### PR TITLE
Prevent invalid SQL with empty RETURNING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3]
+
+### Fixed
+
+- Invalid SQL would be produced by Postgres queries when no RETURNING values were defined
+
 ## [1.0.2]
 
 ### Fixed

--- a/src/Postgres/Traits/CanReturnAfterExecute.php
+++ b/src/Postgres/Traits/CanReturnAfterExecute.php
@@ -22,11 +22,17 @@ trait CanReturnAfterExecute
     // Statement
     public function sql(Identifier $identifier = null): string
     {
+        $sql = parent::sql($identifier);
+
+        if (empty($this->returning)) {
+            return $sql;
+        }
+
         $identifier = $this->getDefaultIdentifier($identifier);
 
         return \sprintf(
             '%s RETURNING %s',
-            parent::sql($identifier),
+            $sql,
             \implode(', ', $identifier->allAliases($this->returning))
         );
     }

--- a/tests/Postgres/UpdateQueryTest.php
+++ b/tests/Postgres/UpdateQueryTest.php
@@ -31,4 +31,27 @@ class UpdateQueryTest extends TestCase
             $update->params()
         );
     }
+
+    public function testUpdateWithoutReturning()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'mr-smith',
+        ];
+
+        $update = UpdateQuery::make($table, $map)
+            ->where(
+                Conditions::make('username = ?', 'jsmith')
+            );
+
+        $this->assertSame(
+            'UPDATE users SET username = ? WHERE username = ?',
+            $update->sql()
+        );
+
+        $this->assertSame(
+            ['mr-smith', 'jsmith'],
+            $update->params()
+        );
+    }
 }


### PR DESCRIPTION
If a Postgres query that supported RETURNING was built without defining
the RETURNING values, it would produce invalid SQL.