### PR TITLE
Allow expressions in insert and update statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0]
+
+### Added
+
+- Expressions can now be used as values for `INSERT` and `UPDATE` queries
+
 ## [1.0.3]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ echo like::escape('[range]');
 ### Expressions
 
 The builder includes a simple wrapper for database expressions which can be used
-for column names in `SELECT` statements.
+for column names in `SELECT` statements and values in other statements:
 
 ```php
 use Latitude\QueryBuilder\Expression as e;
@@ -352,6 +352,22 @@ echo $select->sql();
 // SELECT u.id, COUNT(r.id) AS total FROM users AS u JOIN roles AS r ON r.id = u.role_id GROUP BY u.id
 ```
 
+Expressions can also be used as values in `INSERT` and `UPDATE` statements:
+
+```php
+use Latitude\QueryBuilder\Expression as e;
+
+$insert = InsertQuery::make('users', [
+    'username' => 'ada.love',
+    'created_at' => e::make('NOW()'),
+]);
+
+echo $insert->sql();
+// INSERT INTO users (username, created_at) VALUES (?, NOW())
+
+print_r($insert->params());
+// ["ada.love"]
+```
 
 ### Identifier Escaping
 

--- a/src/Traits/CanReplaceBooleanAndNullValues.php
+++ b/src/Traits/CanReplaceBooleanAndNullValues.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Latitude\QueryBuilder\Traits;
 
+use Latitude\QueryBuilder\Expression;
+
 trait CanReplaceBooleanAndNullValues
 {
     /**
@@ -29,6 +31,11 @@ trait CanReplaceBooleanAndNullValues
         if ($value === null) {
             unset($this->params[$index]);
             return 'NULL';
+        }
+
+        if ($value instanceof Expression) {
+            unset($this->params[$index]);
+            return $value->sql();
         }
 
         return '?';

--- a/tests/InsertQueryTest.php
+++ b/tests/InsertQueryTest.php
@@ -53,4 +53,21 @@ class InsertQueryTest extends TestCase
             'false value' => [false, 'FALSE'],
         ];
     }
+
+    public function testInsertExpression()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'jdoe',
+            'created_at' => Expression::make('NOW()'),
+        ];
+
+        $insert = InsertQuery::make($table, $map);
+
+        $this->assertSame(
+            'INSERT INTO users (username, created_at) VALUES (?, NOW())',
+            $insert->sql()
+        );
+        $this->assertSame(['jdoe'], $insert->params());
+    }
 }


### PR DESCRIPTION
Using expressions such as `NOW()` in inserts and updates is common
practice for handling timestamps. Other applications exist.