### PR TITLE
Fix multiple compiles of insert and update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1]
+
+### Fixed
+
+- Compiling `INSERT` and `UPDATE` queries multiple times could produce different SQL
+
 ## [1.1.0]
 
 ### Added

--- a/src/InsertQuery.php
+++ b/src/InsertQuery.php
@@ -59,7 +59,7 @@ class InsertQuery implements Statement
     // Statement
     public function params(): array
     {
-        return $this->params;
+        return $this->placeholderParams();
     }
 
     /**

--- a/src/Traits/CanReplaceBooleanAndNullValues.php
+++ b/src/Traits/CanReplaceBooleanAndNullValues.php
@@ -18,26 +18,41 @@ trait CanReplaceBooleanAndNullValues
     {
         $value = $this->params[$index];
 
-        if ($value === true) {
-            unset($this->params[$index]);
-            return 'TRUE';
-        }
-
-        if ($value === false) {
-            unset($this->params[$index]);
-            return 'FALSE';
-        }
-
-        if ($value === null) {
-            unset($this->params[$index]);
-            return 'NULL';
+        if ($this->isPlaceholderValue($value)) {
+            return '?';
         }
 
         if ($value instanceof Expression) {
-            unset($this->params[$index]);
             return $value->sql();
         }
 
-        return '?';
+        // null -> "NULL", true -> "TRUE", etc
+        return \strtoupper(\var_export($value, true));
+    }
+
+    /**
+     * Determine if a value can be represented by a placeholder.
+     */
+    protected function isPlaceholderValue($value): bool
+    {
+        if (\in_array($value, [true, false, null], true)) {
+            return false;
+        }
+
+        if ($value instanceof Expression) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get all parameters that can be placeholders.
+     */
+    protected function placeholderParams(): array
+    {
+        return \array_filter($this->params, function ($value) {
+            return $this->isPlaceholderValue($value);
+        });
     }
 }

--- a/src/UpdateQuery.php
+++ b/src/UpdateQuery.php
@@ -73,7 +73,7 @@ class UpdateQuery implements Statement
     // Statement
     public function params(): array
     {
-        return \array_merge($this->params, $this->where->params());
+        return \array_merge($this->placeholderParams(), $this->where->params());
     }
 
     /**

--- a/tests/InsertQueryTest.php
+++ b/tests/InsertQueryTest.php
@@ -70,4 +70,31 @@ class InsertQueryTest extends TestCase
         );
         $this->assertSame(['jdoe'], $insert->params());
     }
+
+    /**
+     * Test for issue #6
+     */
+    public function testMultipleCompile()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'jdoe',
+            'is_employee' => false,
+            'is_manager' => true,
+            'created_at' => Expression::make('NOW()'),
+            'updated_at' => null,
+        ];
+
+        $insert = InsertQuery::make($table, $map);
+
+        $sql = $insert->sql();
+        $params = $insert->params();
+
+        $this->assertContains('(?, FALSE, TRUE, NOW(), NULL)', $sql);
+        $this->assertSame(['jdoe'], $params);
+
+        // Compile again, verifying the same output
+        $this->assertSame($sql, $insert->sql());
+        $this->assertSame($params, $insert->params());
+    }
 }


### PR DESCRIPTION
Due to how null, boolean, and expression values were handled in INSERT
and UPDATE queries, compiling the same query multiple times would result
in different results.

Fixes #6