### PR TITLE
(fix) Reset array keys for params()

### DIFF
--- a/src/Traits/CanReplaceBooleanAndNullValues.php
+++ b/src/Traits/CanReplaceBooleanAndNullValues.php
@@ -51,8 +51,10 @@ trait CanReplaceBooleanAndNullValues
      */
     protected function placeholderParams(): array
     {
-        return \array_filter($this->params, function ($value) {
-            return $this->isPlaceholderValue($value);
-        });
+        return \array_values(
+            \array_filter($this->params, function ($value) {
+                return $this->isPlaceholderValue($value);
+            })
+        );
     }
 }


### PR DESCRIPTION
When generating SQL, null values (and boolean values) are included in the SQL, and not included in the parameters.
By filtering out these parameters, their original index in the array is preserved, which leads a non-sequential keys. It seems PDOStatement::execute() isn't able to figure this out. 

Returning a new array with only the array values fixes this issue. 

HTH