### PR TITLE
(fix) Enabling order by expression

### DIFF
--- a/src/Identifier.php
+++ b/src/Identifier.php
@@ -53,8 +53,12 @@ class Identifier
     /**
      * Escape a (possibly) qualified identifier.
      */
-    public function escapeQualified(string $identifier): string
+    public function escapeQualified($identifier): string
     {
+        if ($this->isExpression($identifier)) {
+            return $identifier->sql($this);
+        }
+
         if (\strpos($identifier, '.') === false) {
             return $this->escape($identifier);
         }

--- a/src/SelectQuery.php
+++ b/src/SelectQuery.php
@@ -256,10 +256,15 @@ class SelectQuery implements Statement
     protected function generateOrderBy(Identifier $identifier): Iterator
     {
         foreach ($this->orderBy as $sort) {
+
+			$escapedIdentifier = $sort[0] instanceof Expression
+				? $sort[0]->sql()
+				: $identifier->escapeQualified($sort[0]);			
+
             if (empty($sort[1])) {
-                yield $identifier->escapeQualified($sort[0]);
+                yield $escapedIdentifier;
             } else {
-                yield $identifier->escapeQualified($sort[0]) . ' ' . \strtoupper($sort[1]);
+                yield $escapedIdentifier . ' ' . \strtoupper($sort[1]);
             }
         }
     }

--- a/src/SelectQuery.php
+++ b/src/SelectQuery.php
@@ -256,15 +256,10 @@ class SelectQuery implements Statement
     protected function generateOrderBy(Identifier $identifier): Iterator
     {
         foreach ($this->orderBy as $sort) {
-
-			$escapedIdentifier = $sort[0] instanceof Expression
-				? $sort[0]->sql()
-				: $identifier->escapeQualified($sort[0]);			
-
             if (empty($sort[1])) {
-                yield $escapedIdentifier;
+                yield $identifier->escapeQualified($sort[0]);
             } else {
-                yield $escapedIdentifier . ' ' . \strtoupper($sort[1]);
+                yield $identifier->escapeQualified($sort[0]) . ' ' . \strtoupper($sort[1]);
             }
         }
     }

--- a/tests/SelectQueryTest.php
+++ b/tests/SelectQueryTest.php
@@ -134,6 +134,18 @@ class SelectQueryTest extends TestCase
         );
     }
 
+	public function testOrderByWithExpression()
+	{
+		$select = SelectQuery::make()
+			->from('users u')
+			->orderBy([e::make('LOWER(u.period)'), 'desc']);
+		
+		$this->assertSame(
+			'SELECT * FROM users AS u ORDER BY LOWER(u.period) DESC',
+			$select->sql()
+		);
+	}
+
     public function testLimitOffset()
     {
         $select = SelectQuery::make()


### PR DESCRIPTION
Extend the orderBy method to allow ordering by Expression as well