### PR TITLE
Use common as the default engine for QueryFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.1]
+
+### Fixed
+
+- Query factory no longer requires an explicit engine
+
 ## [1.2.0]
 
 ### Added

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -11,9 +11,9 @@ class QueryFactory
         'sqlsrv' => 'SqlServer',
     ];
 
-    public function __construct(string $engine, bool $setIdentifier = true)
+    public function __construct(string $engine = null, bool $setIdentifier = true)
     {
-        if (\array_key_exists($engine, static::ENGINES)) {
+        if ($engine && \array_key_exists($engine, static::ENGINES)) {
             $this->engine = static::ENGINES[$engine];
         } else {
             $this->engine = 'Common';

--- a/tests/QueryFactoryTest.php
+++ b/tests/QueryFactoryTest.php
@@ -80,6 +80,14 @@ class QueryFactoryTest extends TestCase
                 DeleteQuery::class,
                 Common\Identifier::class,
             ],
+            'Common' => [
+                '',
+                SelectQuery::class,
+                InsertQuery::class,
+                UpdateQuery::class,
+                DeleteQuery::class,
+                Common\Identifier::class,
+            ],
         ];
     }
 


### PR DESCRIPTION
Makes it easier to mock `QueryFactory` and set up dependency injection.