### PR TITLE
Enable proper HHVM testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,34 @@ cache:
 php:
   - 7.0
   - 7.1
-  - hhvm
 
 matrix:
-  allow_failures:
-    - php: hhvm
+  fast_finish: true
+
   include:
     - php: 7.0
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
+    - php: hhvm-3.15
+      sudo: required
+      dist: trusty
+      group: edge
+
+    - php: hhvm-nightly
+      sudo: required
+      dist: trusty
+      group: edge
+
+  allow_failures:
+    - php: hhvm-nightly
+
 before_script:
+  - |
+    if [[ $TRAVIS_PHP_VERSION = "hhv"* ]]; then
+      # https://github.com/travis-ci/travis-ci/issues/3930
+      cat tests/hhvm.ini > /etc/hhvm/php.ini
+      echo "Enabled PHP7 in HHVM: $?"
+    fi
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:

--- a/tests/hhvm.ini
+++ b/tests/hhvm.ini
@@ -1,0 +1,1 @@
+hhvm.php7.all = 1


### PR DESCRIPTION
HHVM 3.11 added PHP 7 support. Test nightly for possible failures.