### PR TITLE
Update value list internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ the `ValueList` wrapper can be used to expand the `?` placeholder in the conditi
 use Latitude\QueryBuilder\Conditions;
 use Latitude\QueryBuilder\ValueList as in;
 
-$statement = Conditions::make('role IN (?)', in::make(1, 12, 5))
+$statement = Conditions::make('role IN ?', in::make([1, 12, 5]))
 
 echo $statement->sql();
 // role IN (?, ?, ?)

--- a/src/InsertQuery.php
+++ b/src/InsertQuery.php
@@ -54,7 +54,7 @@ class InsertQuery implements Statement
                 \count($this->columns)
             ));
         }
-        $this->values[] = ValueList::make(...$values);
+        $this->values[] = ValueList::make($values);
         return $this;
     }
 
@@ -112,7 +112,7 @@ class InsertQuery implements Statement
     protected function insertLines(): Iterator
     {
         foreach ($this->values as $line) {
-            yield "({$line->sql()})";
+            yield $line->sql();
         }
     }
 

--- a/src/ValueList.php
+++ b/src/ValueList.php
@@ -16,7 +16,7 @@ class ValueList implements
     /**
      * Create a new value list.
      */
-    public static function make(...$params)
+    public static function make(array $params): ValueList
     {
         $values = new static($params);
         $values->params = $params;
@@ -32,7 +32,7 @@ class ValueList implements
     // Statement
     public function sql(Identifier $identifier = null): string
     {
-        return $this->stringifyIterator($this->generatePlaceholders());
+        return '(' . $this->stringifyIterator($this->generatePlaceholders()) . ')';
     }
 
     // Statement

--- a/tests/ConditionsTest.php
+++ b/tests/ConditionsTest.php
@@ -21,14 +21,14 @@ class ConditionsTest extends TestCase
     public function testLogicalIn()
     {
         $conditions = Conditions::make()
-            ->with('role_id IN (?)', ValueList::make(1, 2, 3))
-            ->orWith('user_id IN (?)', ValueList::make(100));
+            ->with('role_id IN ?', ValueList::make([1, 2, 3]))
+            ->orWith('user_id IN ?', ValueList::make([100]));
 
         $this->assertSql($conditions, 'role_id IN (?, ?, ?) OR user_id IN (?)');
         $this->assertParams($conditions, [1, 2, 3, 100]);
 
         $conditions = Conditions::make()
-            ->with('role_id IN (?)', ValueList::make(4, 5, 6));
+            ->with('role_id IN ?', ValueList::make([4, 5, 6]));
 
         $this->assertSql($conditions, 'role_id IN (?, ?, ?)');
         $this->assertParams($conditions, [4, 5, 6]);
@@ -37,7 +37,7 @@ class ConditionsTest extends TestCase
     public function testCombinedStatement()
     {
         $conditions = Conditions::make()
-            ->with('id IN (?) OR id = ?', ValueList::make(5, 10), 1);
+            ->with('id IN ? OR id = ?', ValueList::make([5, 10]), 1);
 
         $this->assertSql($conditions, 'id IN (?, ?) OR id = ?');
         $this->assertParams($conditions, [5, 10, 1]);

--- a/tests/ValueListTest.php
+++ b/tests/ValueListTest.php
@@ -10,18 +10,18 @@ class ValueListTest extends TestCase
 {
     public function testList()
     {
-        $values = ValueList::make(1, 2, 3);
+        $values = ValueList::make([1, 2, 3]);
 
-        $this->assertSame('?, ?, ?', $values->sql());
+        $this->assertSame('(?, ?, ?)', $values->sql());
         $this->assertSame([1,2,3], $values->params());
         $this->assertCount(3, $values);
     }
 
     public function testPlaceholders()
     {
-        $values = ValueList::make(true, false, null, e::make('NOW()'));
+        $values = ValueList::make([true, false, null, e::make('NOW()')]);
 
-        $this->assertSame('TRUE, FALSE, NULL, NOW()', $values->sql());
+        $this->assertSame('(TRUE, FALSE, NULL, NOW())', $values->sql());
         $this->assertSame([], $values->params());
     }
 }


### PR DESCRIPTION
It makes no sense to have unpacked arguments for a value list, since the
construction will almost certainly never be hard coded.

Similarly, it makes no sense to not wrap a value list in parenthesis.