### PR TITLE
Fixed ability grouping by expressions

### DIFF
--- a/src/SelectQuery.php
+++ b/src/SelectQuery.php
@@ -89,9 +89,9 @@ class SelectQuery implements Statement
         return $this;
     }
 
-    public function groupBy(string ...$tables): self
+    public function groupBy(...$columns): self
     {
-        $this->groupBy = $tables;
+        $this->groupBy = $columns;
         return $this;
     }
 

--- a/tests/SelectQueryTest.php
+++ b/tests/SelectQueryTest.php
@@ -150,6 +150,22 @@ class SelectQueryTest extends TestCase
         $this->assertSame([5], $select->params());
     }
 
+    public function testGroupByWithExpression()
+    {
+        $select = SelectQuery::make(
+                e::make('COUNT(*) AS %s', 'total'),
+                e::make('DATE(created_at) AS %s', 'date')
+            )
+            ->from('users')
+            ->groupBy(e::make('DATE(created_at)'))
+            ;
+
+        $this->assertSame(
+            'SELECT COUNT(*) AS total, DATE(created_at) AS date FROM users GROUP BY DATE(created_at)',
+            $select->sql()
+        );
+    }
+
     public function testOrderBy()
     {
         $select = SelectQuery::make()


### PR DESCRIPTION
```php
use Latitude\QueryBuilder\SelectQuery;
use Latitude\QueryBuilder\Expression;

$select = SelectQuery::make(
        Expression::make('DATE(created_at) AS %s', 'date')
    )
    ->from('users')
    ->groupBy(Expression::make('DATE(created_at)')); 

echo $select->sql(); // Should be SELECT DATE(created_at) AS date FROM users GROUP BY DATE(created_at)

// TypeError: Argument 1 passed to Latitude\QueryBuilder\SelectQuery::groupBy() must be of the type string, object given


```