### PR TITLE
add ORDER BY and LIMIT support to UPDATE and DELETE queries in MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ echo $update->sql();
 // UPDATE users SET username = ? WHERE id = ? RETURNING updated_at
 ```
 
+The MySQL extension supports `ORDER BY` and `LIMIT` to limit the number of rows updated:
+
+```php
+use Latitude\QueryBuilder\MySQL\UpdateQuery;
+
+$update = UpdateQuery::make(...)
+    ->orderBy(['username', 'DESC'])
+    ->limit(5);
+
+echo $update->sql();
+// UPDATE users SET updated_at = ? ORDER BY username DESC LIMIT 5
+```
+
 ### DELETE
 
 ```php
@@ -205,6 +218,19 @@ $delete = DeleteQuery::make(...)
 
 echo $delete->sql();
 // DELETE FROM users WHERE last_login IS NULL RETURNING id
+```
+
+The MySQL extension supports `ORDER BY` and `LIMIT` to limit the number of rows deleted:
+
+```php
+use Latitude\QueryBuilder\MySQL\DeleteQuery;
+
+$delete = DeleteQuery::make(...)
+    ->orderBy(['username', 'DESC'])
+    ->limit(5);
+
+echo $delete->sql();
+// DELETE FROM users ORDER BY username DESC LIMIT 5
 ```
 
 ### Factory

--- a/src/MySQL/DeleteQuery.php
+++ b/src/MySQL/DeleteQuery.php
@@ -1,0 +1,38 @@
+<?php
+namespace Latitude\QueryBuilder\MySQL;
+
+use Latitude\QueryBuilder\DeleteQuery as Query;
+use Latitude\QueryBuilder\Identifier;
+use Latitude\QueryBuilder\Traits\CanConvertIteratorToString;
+use Latitude\QueryBuilder\Traits\CanLimit;
+use Latitude\QueryBuilder\Traits\CanOrderBy;
+
+class DeleteQuery extends Query
+{
+    use CanConvertIteratorToString;
+    use CanLimit;
+    use CanOrderBy;
+
+    public function sql(Identifier $identifier = null): string
+    {
+        $identifier = $this->getDefaultIdentifier($identifier);
+
+        $parts = [];
+
+        if ($this->orderBy) {
+            $parts[] = $this->orderByAsSql($identifier);
+        }
+
+        if (isset($this->limit)) {
+            $parts[] = $this->limitAsSql();
+        }
+
+        $sql = parent::sql($identifier);
+
+        if (!$parts) {
+            return $sql;
+        }
+
+        return sprintf('%s %s', $sql, implode(' ', $parts));
+    }
+}

--- a/src/MySQL/UpdateQuery.php
+++ b/src/MySQL/UpdateQuery.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Latitude\QueryBuilder\MySQL;
+
+use Latitude\QueryBuilder\Identifier;
+use Latitude\QueryBuilder\Traits\CanConvertIteratorToString;
+use Latitude\QueryBuilder\Traits\CanLimit;
+use Latitude\QueryBuilder\Traits\CanOrderBy;
+use Latitude\QueryBuilder\UpdateQuery as Query;
+
+class UpdateQuery extends Query
+{
+    use CanConvertIteratorToString;
+    use CanLimit;
+    use CanOrderBy;
+
+    public function sql(Identifier $identifier = null): string
+    {
+        $identifier = $this->getDefaultIdentifier($identifier);
+
+        $parts = [];
+
+        if ($this->orderBy) {
+            $parts[] = $this->orderByAsSql($identifier);
+        }
+
+        if (isset($this->limit)) {
+            $parts[] = $this->limitAsSql();
+        }
+
+        $sql = parent::sql($identifier);
+
+        if (!$parts) {
+            return $sql;
+        }
+
+        return sprintf('%s %s', $sql, implode(' ', $parts));
+    }
+}

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -49,6 +49,10 @@ class QueryFactory
      */
     public function update(...$params): UpdateQuery
     {
+        if ($this->isMySQL()) {
+            return MySQL\UpdateQuery::make(...$params);
+        }
+
         if ($this->isPostgres()) {
             return Postgres\UpdateQuery::make(...$params);
         }
@@ -61,6 +65,10 @@ class QueryFactory
      */
     public function delete(...$params): DeleteQuery
     {
+        if ($this->isMySQL()) {
+            return MySQL\DeleteQuery::make(...$params);
+        }
+
         if ($this->isPostgres()) {
             return Postgres\DeleteQuery::make(...$params);
         }

--- a/src/Traits/CanLimit.php
+++ b/src/Traits/CanLimit.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Latitude\QueryBuilder\Traits;
+
+trait CanLimit
+{
+    public function limit(int $limit): self
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    protected function limitAsSql(): string
+    {
+        return sprintf('LIMIT %d', $this->limit);
+    }
+
+    /**
+     * @var int
+     */
+    protected $limit;
+}

--- a/src/Traits/CanOrderBy.php
+++ b/src/Traits/CanOrderBy.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Latitude\QueryBuilder\Traits;
+
+use Iterator;
+use Latitude\QueryBuilder\Identifier;
+
+trait CanOrderBy
+{
+    public function orderBy(array ...$sorting): self
+    {
+        $this->orderBy = $sorting;
+        return $this;
+    }
+
+    protected function orderByAsSql(Identifier $identifier): string
+    {
+        return sprintf('ORDER BY %s', $this->stringifyIterator($this->generateOrderBy($identifier)));
+    }
+
+    /**
+     * Generate a list of ORDER BY statements.
+     */
+    protected function generateOrderBy(Identifier $identifier): Iterator
+    {
+        foreach ($this->orderBy as $sort) {
+            if (empty($sort[1])) {
+                yield $identifier->escapeQualified($sort[0]);
+            } else {
+                yield $identifier->escapeQualified($sort[0]) . ' ' . \strtoupper($sort[1]);
+            }
+        }
+    }
+
+    /**
+     * @var array
+     */
+    protected $orderBy;
+}

--- a/tests/MySQL/DeleteQueryTest.php
+++ b/tests/MySQL/DeleteQueryTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Latitude\QueryBuilder\MySQL;
+
+use Latitude\QueryBuilder\Conditions;
+use Latitude\QueryBuilder\Expression;
+use PHPUnit\Framework\TestCase;
+
+class DeleteQueryTest extends TestCase
+{
+    public function testWithoutOrderByAndLimit()
+    {
+        $table = 'users';
+
+        $delete = DeleteQuery::make($table)
+            ->where(
+                Conditions::make('last_login IS NULL')
+            );
+
+        $this->assertSame(
+            'DELETE FROM users WHERE last_login IS NULL',
+            $delete->sql()
+        );
+
+        $this->assertSame([], $delete->params());
+    }
+
+    public function testOrderBy()
+    {
+        $table = 'users';
+
+        $delete = DeleteQuery::make($table)
+            ->where(
+                Conditions::make('last_login IS NULL')
+            )->orderBy(['username', 'DESC'], ['id']);
+
+        $this->assertSame(
+            'DELETE FROM users WHERE last_login IS NULL ORDER BY username DESC, id',
+            $delete->sql()
+        );
+
+        $this->assertSame([], $delete->params());
+    }
+
+    public function testOrderByWithExpression()
+    {
+        $table = 'users';
+
+        $delete = DeleteQuery::make($table)
+            ->where(
+                Conditions::make('last_login IS NULL')
+            )->orderBy([Expression::make('LOWER(u.period)'), 'desc']);
+
+        $this->assertSame(
+            'DELETE FROM users WHERE last_login IS NULL ORDER BY LOWER(u.period) DESC',
+            $delete->sql()
+        );
+
+        $this->assertSame([], $delete->params());
+    }
+
+    public function testLimit()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'mr-smith',
+        ];
+
+        $delete = DeleteQuery::make($table)
+            ->where(
+                Conditions::make('last_login IS NULL')
+            )->limit(50);
+
+        $this->assertSame(
+            'DELETE FROM users WHERE last_login IS NULL LIMIT 50',
+            $delete->sql()
+        );
+
+        $this->assertSame([], $delete->params());
+    }
+}

--- a/tests/MySQL/UpdateQueryTest.php
+++ b/tests/MySQL/UpdateQueryTest.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace Latitude\QueryBuilder\MySQL;
+
+use Latitude\QueryBuilder\Conditions;
+use Latitude\QueryBuilder\Expression;
+use PHPUnit\Framework\TestCase;
+
+class UpdateQueryTest extends TestCase
+{
+    public function testWithoutOrderByAndLimit()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'mr-smith',
+        ];
+
+        $update = UpdateQuery::make($table, $map)
+            ->where(
+                Conditions::make('username = ?', 'jsmith')
+            );
+
+        $this->assertSame(
+            'UPDATE users SET username = ? WHERE username = ?',
+            $update->sql()
+        );
+
+        $this->assertSame(
+            ['mr-smith', 'jsmith'],
+            $update->params()
+        );
+    }
+
+    public function testOrderBy()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'mr-smith',
+        ];
+
+        $update = UpdateQuery::make($table, $map)
+            ->where(
+                Conditions::make('username = ?', 'jsmith')
+            )->orderBy(['username', 'DESC'], ['id']);
+
+        $this->assertSame(
+            'UPDATE users SET username = ? WHERE username = ? ORDER BY username DESC, id',
+            $update->sql()
+        );
+
+        $this->assertSame(
+            ['mr-smith', 'jsmith'],
+            $update->params()
+        );
+    }
+
+    public function testOrderByWithExpression()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'mr-smith',
+        ];
+
+        $update = UpdateQuery::make($table, $map)
+            ->where(
+                Conditions::make('username = ?', 'jsmith')
+            )->orderBy([Expression::make('LOWER(u.period)'), 'desc']);
+
+        $this->assertSame(
+            'UPDATE users SET username = ? WHERE username = ? ORDER BY LOWER(u.period) DESC',
+            $update->sql()
+        );
+
+        $this->assertSame(
+            ['mr-smith', 'jsmith'],
+            $update->params()
+        );
+    }
+
+    public function testLimit()
+    {
+        $table = 'users';
+        $map = [
+            'username' => 'mr-smith',
+        ];
+
+        $update = UpdateQuery::make($table, $map)
+            ->where(
+                Conditions::make('username = ?', 'jsmith')
+            )->limit(50);
+
+        $this->assertSame(
+            'UPDATE users SET username = ? WHERE username = ? LIMIT 50',
+            $update->sql()
+        );
+
+        $this->assertSame(
+            ['mr-smith', 'jsmith'],
+            $update->params()
+        );
+    }
+}

--- a/tests/QueryFactoryTest.php
+++ b/tests/QueryFactoryTest.php
@@ -52,8 +52,8 @@ class QueryFactoryTest extends TestCase
                 'mysql',
                 SelectQuery::class,
                 InsertQuery::class,
-                UpdateQuery::class,
-                DeleteQuery::class,
+                MySQL\UpdateQuery::class,
+                MySQL\DeleteQuery::class,
                 MySQL\Identifier::class,
             ],
             'Postgres' => [


### PR DESCRIPTION
MySQL supports `ORDER BY` and `LIMIT` in `UPDATE` and `DELETE` queries. This PR adds support for that.

See https://dev.mysql.com/doc/refman/5.5/en/update.html and https://dev.mysql.com/doc/refman/5.5/en/delete.html for more information about this feature.