### PR TITLE
Reset all the parts!

### DIFF
--- a/src/SelectQuery.php
+++ b/src/SelectQuery.php
@@ -29,7 +29,7 @@ class SelectQuery implements Statement
 
     public function columns(...$columns): self
     {
-        $this->columns = $columns;
+        $this->columns = $columns ?: null;
         return $this;
     }
 
@@ -85,7 +85,13 @@ class SelectQuery implements Statement
         return $this->join($table, $conditions, 'FULL OUTER');
     }
 
-    public function where(Conditions $where): self
+    public function resetJoins()
+    {
+        $this->join = [];
+        return $this;
+    }
+
+    public function where(Conditions $where = null): self
     {
         $this->where = $where;
         return $this;
@@ -93,11 +99,11 @@ class SelectQuery implements Statement
 
     public function groupBy(...$columns): self
     {
-        $this->groupBy = $columns;
+        $this->groupBy = $columns ?: null;
         return $this;
     }
 
-    public function having(Conditions $having): self
+    public function having(Conditions $having = null): self
     {
         $this->having = $having;
         return $this;

--- a/src/Traits/CanOrderBy.php
+++ b/src/Traits/CanOrderBy.php
@@ -10,7 +10,7 @@ trait CanOrderBy
 {
     public function orderBy(array ...$sorting): self
     {
-        $this->orderBy = $sorting;
+        $this->orderBy = $sorting ?: null;
         return $this;
     }
 

--- a/tests/SelectQueryTest.php
+++ b/tests/SelectQueryTest.php
@@ -203,31 +203,32 @@ class SelectQueryTest extends TestCase
         );
     }
 
-    public function testLimitReset()
+    public function testResetQuery()
     {
         $select = SelectQuery::make()
+            ->columns(['id', 'name'])
+            ->join('roles', c::make('roles.user_id = users.id'), 'INNER')
             ->from('users')
-            ->limit(50);
+            ->where(c::make('foo = bar'))
+            ->groupBy('foos')
+            ->having(c::make('COUNT(DISTINCT bar) > 1'))
+            ->orderBy(['id', 'DESC'])
+            ->offset(200)
+            ->limit(50)
+        ;
 
-        $select->limit(null);
+        $select->columns()
+            ->where()
+            ->groupBy()
+            ->having()
+            ->orderBy()
+            ->offset()
+            ->limit()
+            ->resetJoins()
+        ;
 
         $this->assertSame(
             'SELECT * FROM users',
-            $select->sql()
-        );
-    }
-
-    public function testOffsetReset()
-    {
-        $select = SelectQuery::make()
-            ->from('users')
-            ->offset(100)
-            ->limit(50);
-
-        $select->offset(null);
-
-        $this->assertSame(
-            'SELECT * FROM users LIMIT 50',
             $select->sql()
         );
     }


### PR DESCRIPTION
Following #31... I just figured out that I could not remove the `orderBy` part when cloning a query for pagination. The produced query is valid SQL but this leads to a performance issue (no need to sort results if the only goal is to count them).

Since the query is entirely mutable, I think everything should be resetable.

So here's a new PR to ensure every part can be reset.
Only the `join` part is a little touchy, so I added a `resetJoins()` method, and refactored the unit test.

What do you think?