### PR TITLE
Fix value list values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.1]
+
+### Fixed
+
+- Normalize `ValueList` parameters when passed an array
+
 ## [2.3.0]
 
 ### Added

--- a/src/ValueList.php
+++ b/src/ValueList.php
@@ -19,7 +19,7 @@ class ValueList implements
     public static function make(array $params): ValueList
     {
         $values = new static($params);
-        $values->params = $params;
+        $values->params = array_values($params);
         return $values;
     }
 

--- a/tests/ValueListTest.php
+++ b/tests/ValueListTest.php
@@ -24,4 +24,12 @@ class ValueListTest extends TestCase
         $this->assertSame('(TRUE, FALSE, NULL, NOW())', $values->sql());
         $this->assertSame([], $values->params());
     }
+
+    public function testMap()
+    {
+        $values = ValueList::make(['a' => 'a', 'b' => 'b', 'c' => 'c']);
+
+        $this->assertSame('(?, ?, ?)', $values->sql());
+        $this->assertSame(['a', 'b', 'c'], $values->params());
+    }
 }


### PR DESCRIPTION
The value list should always be a list of values, never a map.

Passing a map would cause type errors if the map used string keys.