### PR TITLE
Add Psalm to composer test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,11 @@
     },
     "scripts": {
         "test-stan": "phpstan analyse --level=1 --no-progress src tests",
+        "test-psalm": "psalm",
         "test-unit": "phpunit",
         "test": [
             "@test-stan",
+            "@test-psalm",
             "@test-unit"
         ]
     },


### PR DESCRIPTION
Ref https://github.com/shadowhand/latitude/issues/38

Actually adds to Travis.

If you don't want the warnings, you can add `--show-info=false`