### PR TITLE
Update Psalm and hide warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "eloquent/liberator": "^2.0",
         "phpstan/phpstan": "^0.9.1",
         "phpunit/phpunit": "^6.0",
-        "vimeo/psalm": "^0.3.70"
+        "vimeo/psalm": "^0.3.78"
     },
     "autoload": {
         "files": [
@@ -34,10 +34,11 @@
     },
     "scripts": {
         "test-stan": "phpstan analyse --level=1 --no-progress src tests",
-        "test-psalm": "psalm",
+        "test-psalm": "psalm --show-info=false",
         "test-unit": "phpunit",
         "test": [
             "@test-stan",
+            "@test-psalm",
             "@test-unit"
         ]
     },


### PR DESCRIPTION
Ref https://travis-ci.org/shadowhand/latitude/builds/326580613

This bumps the version of Psalm to include a release that [fixes the bug](https://github.com/vimeo/psalm/commit/3f3c1380eec9d7aa6cd1ce600fadab5e005673c0) that caused the single error.

It also hides Psalm's warnings, which aren't needed in the build output (and caused confusion here).