### PR TITLE
Output boolean and null values in SQL

### DIFF
--- a/src/Partial/Parameter.php
+++ b/src/Partial/Parameter.php
@@ -8,21 +8,28 @@ use Latitude\QueryBuilder\StatementInterface;
 
 final class Parameter implements StatementInterface
 {
-    /** @var mixed */
-    private $value;
+    /** @var string */
+    private $sql = '?';
+
+    /** @var array */
+    private $params = [];
 
     public function __construct($value)
     {
-        $this->value = $value;
+        if (is_bool($value) || is_null($value)) {
+            $this->sql = var_export($value, true);
+        } else {
+            $this->params[] = $value;
+        }
     }
 
     public function sql(EngineInterface $engine): string
     {
-        return '?';
+        return $this->sql;
     }
 
     public function params(EngineInterface $engine): array
     {
-        return [$this->value];
+        return $this->params;
     }
 }

--- a/tests/Partial/CriteriaTest.php
+++ b/tests/Partial/CriteriaTest.php
@@ -97,18 +97,29 @@ class CriteriaTest extends TestCase
         $this->assertParams([], $expr);
     }
 
+    public function testBoolean()
+    {
+        $expr = field('is_active')->eq(true);
+
+        $this->assertSql('is_active = true', $expr);
+
+        $expr = field('is_active')->eq(false);
+
+        $this->assertSql('is_active = false', $expr);
+    }
+
     public function testAnd()
     {
         $expr = field('id')->eq(5);
-        $expr = $expr->and(field('is_active')->eq(true));
+        $expr = $expr->and(field('is_active')->eq(1));
 
         $this->assertSql('id = ? AND is_active = ?', $expr);
     }
 
     public function testOr()
     {
-        $expr = field('is_deleted')->eq(true);
-        $expr = $expr->or(field('is_inactive')->eq(true));
+        $expr = field('is_deleted')->eq(1);
+        $expr = $expr->or(field('is_inactive')->eq(1));
 
         $this->assertSql('is_deleted = ? OR is_inactive = ?', $expr);
     }

--- a/tests/Query/Postgres/UpdateTest.php
+++ b/tests/Query/Postgres/UpdateTest.php
@@ -16,7 +16,7 @@ class UpdateTest extends TestCase
             ])
             ->returning('id');
 
-        $this->assertSql('UPDATE "users" SET "last_login" = ? RETURNING "id"', $update);
-        $this->assertParams([null], $update);
+        $this->assertSql('UPDATE "users" SET "last_login" = NULL RETURNING "id"', $update);
+        $this->assertParams([], $update);
     }
 }

--- a/tests/Query/UpdateTest.php
+++ b/tests/Query/UpdateTest.php
@@ -24,8 +24,8 @@ class UpdateTest extends TestCase
                 'last_login' => null,
             ]);
 
-        $this->assertSql('UPDATE users SET last_login = ?', $update);
-        $this->assertParams([null], $update);
+        $this->assertSql('UPDATE users SET last_login = NULL', $update);
+        $this->assertParams([], $update);
     }
 
     public function testWhere()


### PR DESCRIPTION
PDO will try to cast boolean and null values to strings, which can
corrupt INSERT/UPDATE queries and mess with boolean comparisons.

Fixes #55 