### PR TITLE
Basic grouping support for `or` operator (issue #83).

### DIFF
--- a/src/Ruler/Visitor.php
+++ b/src/Ruler/Visitor.php
@@ -14,6 +14,7 @@ use function Latitude\QueryBuilder\identify;
 use function Latitude\QueryBuilder\listing;
 use function Latitude\QueryBuilder\literal;
 use function Latitude\QueryBuilder\param;
+use function Latitude\QueryBuilder\group;
 
 class Visitor implements VisitorInterface
 {
@@ -100,6 +101,10 @@ class Visitor implements VisitorInterface
     protected function visitOperator(Ast\Operator $element, &$handle = null, $eldnah = null)
     {
         $values = array_map($this->remapper($handle, $eldnah), $element->getArguments());
+
+        if ($element->getName() === 'or') {
+            return group(criteria(sprintf('%%s %s %%s', $element->getName()), $values[0], $values[1]));
+        }
 
         if ($element->isFunction()) {
             return criteria(sprintf('%s(%%s)', strtoupper($element->getName())), listing($values));

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -53,4 +53,41 @@ class CriteriaTest extends TestCase
 
         $this->factory->criteria('id.foo() = 1');
     }
+
+    public function testGrouping()
+    {
+        $criteria = $this->factory->criteria('(users.id = 25 or users.role = "admin") and users.active = true');
+        $this->assertSql('(users.id = ? or users.role = ?) and users.active = true', $criteria);
+        $this->assertParams([25, 'admin'], $criteria);
+
+        $criteria = $this->factory->criteria('users.active = true and users.id = 33 or users.role = "operator"');
+        $this->assertSql('(users.active = true and users.id = ? or users.role = ?)', $criteria);
+        $this->assertParams([33, 'operator'], $criteria);
+
+        $criteria = $this->factory->criteria('users.active = true and (users.id = 68 or users.role = "admin")');
+        $this->assertSql('users.active = true and (users.id = ? or users.role = ?)', $criteria);
+        $this->assertParams([68, 'admin'], $criteria);
+
+        $criteria = $this->factory->criteria(
+            'users.active = true and (users.id = 69 or users.role = "admin" or users.name = "John")'
+        );
+        $this->assertSql('users.active = true and (users.id = ? or (users.role = ? or users.name = ?))', $criteria);
+        $this->assertParams([69, 'admin', 'John'], $criteria);
+
+        $criteria = $this->factory->criteria(
+            'users.active = true and (users.id = 34 or users.role = "admin" and users.name = "Sam")'
+        );
+        $this->assertSql('users.active = true and (users.id = ? or users.role = ? and users.name = ?)', $criteria);
+        $this->assertParams([34, 'admin', 'Sam'], $criteria);
+
+        $criteria = $this->factory->criteria(
+            'users.active = true and (users.id = 71 or users.role = "admin" ' .
+            'and (users.name = "Adam" or users.name = "Natalie"))'
+        );
+        $this->assertSql(
+            'users.active = true and (users.id = ? or users.role = ? and (users.name = ? or users.name = ?))',
+            $criteria
+        );
+        $this->assertParams([71, 'admin', 'Adam', 'Natalie'], $criteria);
+    }
 }


### PR DESCRIPTION
This is the best I could do for now.
The patch is kind of dirty as it **always** encloses `or` parameters with single brackets `(... or ...)`, but this is - if my mind is not playing tricks with me - logically neutral.

Still - I'm not 100% sure if I have covered all possible situations with tests and if these wrapping brackets are actually 100% safe.

Please check.