### PR TITLE
Enhancing string transformation

### DIFF
--- a/src/Ruler/Visitor.php
+++ b/src/Ruler/Visitor.php
@@ -106,7 +106,14 @@ class Visitor implements VisitorInterface
         }
 
         if (count($values) === 2) {
-            return criteria(sprintf('%%s %s %%s', $element->getName()), $values[0], $values[1]);
+            $operator = $element->getName();
+            // `NULL` requires operator replacements: `=` becomes `IS` and `!=` becomes `IS NOT`
+            $parameter = $element->getArguments()[1];
+            if ($parameter instanceof Ast\Bag\Scalar and is_null($parameter->getValue())) {
+                $operator = $element->getName() === '!=' ? 'IS NOT' : 'IS';
+            }
+
+            return criteria(sprintf('%%s %s %%s', strtoupper($operator)), $values[0], $values[1]);
         }
 
         return criteria(sprintf('%s (%%s)', $element->getName()), listing($values, ' '));

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -18,7 +18,7 @@ class CriteriaTest extends TestCase
     {
         $criteria = $this->factory->criteria('employees.role in ["manager", "supervisor"]');
 
-        $this->assertSql('employees.role in (?, ?)', $criteria);
+        $this->assertSql('employees.role IN (?, ?)', $criteria);
         $this->assertParams(['manager', 'supervisor'], $criteria);
     }
 
@@ -42,8 +42,19 @@ class CriteriaTest extends TestCase
     {
         $criteria = $this->factory->criteria('not (id in [1, 2])');
 
-        $this->assertSql('not (id in (?, ?))', $criteria);
+        $this->assertSql('not (id IN (?, ?))', $criteria);
         $this->assertParams([1, 2], $criteria);
+    }
+
+    public function testNullComparision()
+    {
+        $criteria = $this->factory->criteria('users.active = null');
+
+        $this->assertSql('users.active IS NULL', $criteria);
+
+        $criteria = $this->factory->criteria('users.active != null');
+
+        $this->assertSql('users.active IS NOT NULL', $criteria);
     }
 
     public function testMethodNotSupported()


### PR DESCRIPTION
It appears that SQL does not like using operators `=` and `!=` when used with `null` values.
They should be replaced by `IS` and `IS NOT`.