### PR TITLE
Separate SQLite engine due to boolean parameters conversion (#83)

### DIFF
--- a/docs/engines.md
+++ b/docs/engines.md
@@ -18,9 +18,6 @@ The standard SQL-92 engine is `Latitude\QueryBuilder\Engine\CommonEngine`.
 This engine escapes all identifiers using double quotes. No other additional
 features are provided.
 
-This engine is recommended for most databases without a more specific engine,
-such as SQLite.
-
 ## MySQL Engine
 
 The MySQL engine is `Latitude\QueryBuilder\Engine\MySqlEngine`. This engine
@@ -40,3 +37,11 @@ escapes all identifiers using brackets. It also escapes brackets used in `LIKE`
 expressions, preventing the usage of character ranges.
 
 _**Note**: This engine relies on features found in SQL Server 2012 and above._
+
+## SQLite Engine
+
+The SQLite engine is `Latitude\QueryBuilder\Engine\SqliteEngine`. This engine
+converts boolean values into small integers because SQLite does not have
+a separate boolean storage class. Instead, boolean values are stored as
+integers: `0` (false) and `1` (true).
+

--- a/src/Engine/BasicEngine.php
+++ b/src/Engine/BasicEngine.php
@@ -42,6 +42,15 @@ class BasicEngine implements EngineInterface
         return str_replace(['%', '_'], ['\\%', '\\_'], $parameter);
     }
 
+    public function getSqlParamValue($value): string
+    {
+        if (is_null($value) or is_bool($value)) {
+            return var_export($value, true);
+        }
+
+        return $value;
+    }
+
     final public function extractParams(): callable
     {
         return function (StatementInterface $statement): array {

--- a/src/Engine/BasicEngine.php
+++ b/src/Engine/BasicEngine.php
@@ -44,7 +44,7 @@ class BasicEngine implements EngineInterface
 
     public function exportParameter($param): string
     {
-        if (is_null($param) or is_bool($param)) {
+        if (is_null($param) || is_bool($param)) {
             return var_export($param, true);
         }
 

--- a/src/Engine/BasicEngine.php
+++ b/src/Engine/BasicEngine.php
@@ -42,13 +42,13 @@ class BasicEngine implements EngineInterface
         return str_replace(['%', '_'], ['\\%', '\\_'], $parameter);
     }
 
-    public function getSqlParamValue($value): string
+    public function exportParameter($param): string
     {
-        if (is_null($value) or is_bool($value)) {
-            return var_export($value, true);
+        if (is_null($param) or is_bool($param)) {
+            return var_export($param, true);
         }
 
-        return $value;
+        return $param;
     }
 
     final public function extractParams(): callable

--- a/src/Engine/SqliteEngine.php
+++ b/src/Engine/SqliteEngine.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Latitude\QueryBuilder\Engine;
+
+class SqliteEngine extends BasicEngine
+{
+    public function getSqlParamValue($value): string
+    {
+        if (is_bool($value)) {
+            return (string) (int) $value;
+        }
+
+        return parent::getSqlParamValue($value);
+    }
+}

--- a/src/Engine/SqliteEngine.php
+++ b/src/Engine/SqliteEngine.php
@@ -5,12 +5,14 @@ namespace Latitude\QueryBuilder\Engine;
 
 class SqliteEngine extends BasicEngine
 {
-    public function getSqlParamValue($value): string
+    public function exportParameter($param): string
     {
-        if (is_bool($value)) {
-            return (string) (int) $value;
+        if (is_bool($param)) {
+            // Convert boolean to stringified integer. SQLite does not have a separate boolean storage class.
+            // Instead, boolean values are stored as integers 0 (false) and 1 (true).
+            return (string) (int) $param;
         }
 
-        return parent::getSqlParamValue($value);
+        return parent::exportParameter($param);
     }
 }

--- a/src/EngineInterface.php
+++ b/src/EngineInterface.php
@@ -60,8 +60,7 @@ interface EngineInterface
     public function flattenSql(string $separator = ' ', StatementInterface ...$statements): string;
 
     /**
-     * Get a query parameter that does not need to be escaped but may be a subject of conversion (like `true` → `1` for
-     * SQLite).
+     * Export a query parameter that may need engine-specific formatting
      */
-    public function getSqlParamValue($value): string;
+    public function exportParameter($param): string;
 }

--- a/src/EngineInterface.php
+++ b/src/EngineInterface.php
@@ -58,4 +58,10 @@ interface EngineInterface
      * Flatten all SQL from multiple statements
      */
     public function flattenSql(string $separator = ' ', StatementInterface ...$statements): string;
+
+    /**
+     * Get a query parameter that does not need to be escaped but may be a subject of conversion (like `true` → `1` for
+     * SQLite).
+     */
+    public function getSqlParamValue($value): string;
 }

--- a/src/Partial/Parameter.php
+++ b/src/Partial/Parameter.php
@@ -17,7 +17,7 @@ final class Parameter implements StatementInterface
     public function __construct($value)
     {
         if (is_bool($value) || is_null($value)) {
-            $this->sql = var_export($value, true);
+            $this->sql = $value;
         } else {
             $this->params[] = $value;
         }
@@ -25,7 +25,7 @@ final class Parameter implements StatementInterface
 
     public function sql(EngineInterface $engine): string
     {
-        return $this->sql;
+        return $engine->getSqlParamValue($this->sql);
     }
 
     public function params(EngineInterface $engine): array

--- a/src/Partial/Parameter.php
+++ b/src/Partial/Parameter.php
@@ -25,7 +25,7 @@ final class Parameter implements StatementInterface
 
     public function sql(EngineInterface $engine): string
     {
-        return $engine->getSqlParamValue($this->sql);
+        return $engine->exportParameter($this->sql);
     }
 
     public function params(EngineInterface $engine): array

--- a/tests/Engine/SqliteTest.php
+++ b/tests/Engine/SqliteTest.php
@@ -7,18 +7,18 @@ use Latitude\QueryBuilder\TestCase;
 use function Latitude\QueryBuilder\field;
 use function Latitude\QueryBuilder\identify;
 
-class MySqlTest extends TestCase
+class SqliteTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->engine = new MySqlEngine();
+        $this->engine = new SqliteEngine();
     }
 
-    public function testIdentifier(): void
+    public function testIdentifier()
     {
         $field = identify('id');
 
-        $this->assertSql('`id`', $field);
+        $this->assertSql('id', $field);
     }
 
     public function testBooleanParameterValue()
@@ -26,25 +26,25 @@ class MySqlTest extends TestCase
         $criteria = field('active')->eq(true);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = true', $sql);
+        $this->assertEquals('active = 1', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(false);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = false', $sql);
+        $this->assertEquals('active = 0', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(null);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = NULL', $sql);
+        $this->assertEquals('active = NULL', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq('yes');
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = ?', $sql);
+        $this->assertEquals('active = ?', $sql);
         $this->assertEquals(['yes'], $params);
     }
 }


### PR DESCRIPTION
Following guidelines provided by @shadowhand this should fix the problem with using small integers as booleans within the SQLite engine.
New tests included.