### PR TITLE
Using assertSame to make assert equals strict

### DIFF
--- a/tests/Engine/MySqlTest.php
+++ b/tests/Engine/MySqlTest.php
@@ -26,25 +26,25 @@ class MySqlTest extends TestCase
         $criteria = field('active')->eq(true);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = true', $sql);
+        $this->assertSame('`active` = true', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(false);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = false', $sql);
+        $this->assertSame('`active` = false', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(null);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = NULL', $sql);
+        $this->assertSame('`active` = NULL', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq('yes');
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('`active` = ?', $sql);
+        $this->assertSame('`active` = ?', $sql);
         $this->assertEquals(['yes'], $params);
     }
 }

--- a/tests/Engine/SqliteTest.php
+++ b/tests/Engine/SqliteTest.php
@@ -26,25 +26,25 @@ class SqliteTest extends TestCase
         $criteria = field('active')->eq(true);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('active = 1', $sql);
+        $this->assertSame('active = 1', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(false);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('active = 0', $sql);
+        $this->assertSame('active = 0', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(null);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('active = NULL', $sql);
+        $this->assertSame('active = NULL', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq('yes');
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertEquals('active = ?', $sql);
+        $this->assertSame('active = ?', $sql);
         $this->assertEquals(['yes'], $params);
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assert equals strict.