### PR TITLE
Improve identifier escaping

### DIFF
--- a/src/Builder/CriteriaBuilder.php
+++ b/src/Builder/CriteriaBuilder.php
@@ -37,65 +37,49 @@ class CriteriaBuilder
         return criteria('%s NOT BETWEEN %s AND %s', $this->statement, $start, $end);
     }
 
-    /**
-     * @param mixed ...$values
-     */
+    /** @param mixed ...$values */
     public function in(...$values): CriteriaInterface
     {
         return criteria('%s IN (%s)', $this->statement, listing($values));
     }
 
-    /**
-     * @param mixed ...$values
-     */
+    /** @param mixed ...$values */
     public function notIn(...$values): CriteriaInterface
     {
         return criteria('%s NOT IN (%s)', $this->statement, listing($values));
     }
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function eq($value): CriteriaInterface
     {
         return criteria('%s = %s', $this->statement, $value);
     }
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function notEq($value): CriteriaInterface
     {
         return criteria('%s != %s', $this->statement, $value);
     }
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function gt($value): CriteriaInterface
     {
         return criteria('%s > %s', $this->statement, $value);
     }
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function gte($value): CriteriaInterface
     {
         return criteria('%s >= %s', $this->statement, $value);
     }
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function lt($value): CriteriaInterface
     {
         return criteria('%s < %s', $this->statement, $value);
     }
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function lte($value): CriteriaInterface
     {
         return criteria('%s <= %s', $this->statement, $value);

--- a/src/Engine/BasicEngine.php
+++ b/src/Engine/BasicEngine.php
@@ -51,9 +51,7 @@ class BasicEngine implements EngineInterface
         return str_replace(['%', '_'], ['\\%', '\\_'], $parameter);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function exportParameter($param): string
     {
         if (is_string($param)) {

--- a/src/Engine/CommonEngine.php
+++ b/src/Engine/CommonEngine.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Latitude\QueryBuilder\Engine;
 
 use function sprintf;
+use function str_replace;
 
 class CommonEngine extends BasicEngine
 {
     public function escapeIdentifier(string $identifier): string
     {
-        return sprintf('"%s"', str_replace( '"', '""', $identifier));
+        return sprintf('"%s"', str_replace('"', '""', $identifier));
     }
 }

--- a/src/Engine/CommonEngine.php
+++ b/src/Engine/CommonEngine.php
@@ -10,6 +10,6 @@ class CommonEngine extends BasicEngine
 {
     public function escapeIdentifier(string $identifier): string
     {
-        return sprintf('"%s"', $identifier);
+        return sprintf('"%s"', str_replace( '"', '""', $identifier));
     }
 }

--- a/src/Engine/MySqlEngine.php
+++ b/src/Engine/MySqlEngine.php
@@ -7,6 +7,7 @@ namespace Latitude\QueryBuilder\Engine;
 use Latitude\QueryBuilder\Query;
 
 use function sprintf;
+use function str_replace;
 
 class MySqlEngine extends BasicEngine
 {

--- a/src/Engine/MySqlEngine.php
+++ b/src/Engine/MySqlEngine.php
@@ -22,6 +22,6 @@ class MySqlEngine extends BasicEngine
 
     public function escapeIdentifier(string $identifier): string
     {
-        return sprintf('`%s`', $identifier);
+        return sprintf('`%s`', str_replace('`', '``', $identifier));
     }
 }

--- a/src/Engine/SqlServerEngine.php
+++ b/src/Engine/SqlServerEngine.php
@@ -23,7 +23,7 @@ class SqlServerEngine extends BasicEngine
 
     public function escapeIdentifier(string $identifier): string
     {
-        return sprintf('[%s]', $identifier);
+        return sprintf('[%s]', str_replace(']', ']]', $identifier));
     }
 
     public function escapeLike(string $parameter): string

--- a/src/Engine/SqliteEngine.php
+++ b/src/Engine/SqliteEngine.php
@@ -8,9 +8,7 @@ use function is_bool;
 
 class SqliteEngine extends BasicEngine
 {
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function exportParameter($param): string
     {
         if (is_bool($param)) {

--- a/src/Engine/SqliteEngine.php
+++ b/src/Engine/SqliteEngine.php
@@ -6,7 +6,7 @@ namespace Latitude\QueryBuilder\Engine;
 
 use function is_bool;
 
-class SqliteEngine extends BasicEngine
+class SqliteEngine extends CommonEngine
 {
     /** @inheritDoc */
     public function exportParameter($param): string

--- a/src/Partial/Literal.php
+++ b/src/Partial/Literal.php
@@ -12,9 +12,7 @@ final class Literal implements StatementInterface
     /** @var mixed */
     private $value;
 
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function __construct($value)
     {
         $this->value = $value;

--- a/src/Partial/Parameter.php
+++ b/src/Partial/Parameter.php
@@ -13,9 +13,7 @@ use function is_bool;
 
 final class Parameter implements StatementInterface
 {
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public static function create($value): StatementInterface
     {
         if ($value === null) {
@@ -32,9 +30,7 @@ final class Parameter implements StatementInterface
     private string $sql = '?';
     private array $params;
 
-    /**
-     * @param string|float|int $value
-     */
+    /** @param string|float|int $value */
     public function __construct($value)
     {
         $this->params = [$value];

--- a/src/Query/AbstractQuery.php
+++ b/src/Query/AbstractQuery.php
@@ -29,7 +29,7 @@ abstract class AbstractQuery implements QueryInterface
 
         return new Query(
             $query->sql($this->engine),
-            $query->params($this->engine)
+            $query->params($this->engine),
         );
     }
 

--- a/src/Query/Capability/HasFrom.php
+++ b/src/Query/Capability/HasFrom.php
@@ -14,9 +14,7 @@ trait HasFrom
 {
     protected array $from = [];
 
-    /**
-     * @param mixed ...$tables
-     */
+    /** @param mixed ...$tables */
     public function from(...$tables): self
     {
         $this->from = identifyAll($tables);
@@ -24,9 +22,7 @@ trait HasFrom
         return $this;
     }
 
-    /**
-     * @param mixed ...$tables
-     */
+    /** @param mixed ...$tables */
     public function addFrom(...$tables): self
     {
         return $this->from(...array_merge($this->from, $tables));

--- a/src/Query/Capability/HasOrderBy.php
+++ b/src/Query/Capability/HasOrderBy.php
@@ -13,9 +13,7 @@ trait HasOrderBy
 {
     protected array $orderBy = [];
 
-    /**
-     * @param mixed $column
-     */
+    /** @param mixed $column */
     public function orderBy($column, string $direction = ''): self
     {
         if (! $column) {

--- a/src/Query/Capability/HasReturning.php
+++ b/src/Query/Capability/HasReturning.php
@@ -13,9 +13,7 @@ trait HasReturning
 {
     protected ?StatementInterface $returning = null;
 
-    /**
-     * @param mixed $column
-     */
+    /** @param mixed $column */
     public function returning($column): self
     {
         $this->returning = identify($column);

--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -21,9 +21,7 @@ class InsertQuery extends AbstractQuery
     protected ?StatementInterface $columns = null;
     protected array $values = [];
 
-    /**
-     * @param mixed $table
-     */
+    /** @param mixed $table */
     public function into($table): self
     {
         $this->into = identify($table);
@@ -36,9 +34,7 @@ class InsertQuery extends AbstractQuery
         return $this->columns(...array_keys($map))->values(...array_values($map));
     }
 
-    /**
-     * @param mixed ...$columns
-     */
+    /** @param mixed ...$columns */
     public function columns(...$columns): self
     {
         $this->columns = listing(identifyAll($columns));
@@ -46,9 +42,7 @@ class InsertQuery extends AbstractQuery
         return $this;
     }
 
-    /**
-     * @param mixed ...$params
-     */
+    /** @param mixed ...$params */
     public function values(...$params): self
     {
         $this->values[] = express('(%s)', listing(paramAll($params)));

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -40,9 +40,7 @@ class SelectQuery extends AbstractQuery
         return $this;
     }
 
-    /**
-     * @param mixed ...$columns
-     */
+    /** @param mixed ...$columns */
     public function columns(...$columns): self
     {
         $this->columns = identifyAll($columns);
@@ -50,17 +48,13 @@ class SelectQuery extends AbstractQuery
         return $this;
     }
 
-    /**
-     * @param mixed ...$columns
-     */
+    /** @param mixed ...$columns */
     public function addColumns(...$columns): self
     {
         return $this->columns(...array_merge($this->columns, $columns));
     }
 
-    /**
-     * @param StatementInterface|string $table
-     */
+    /** @param StatementInterface|string $table */
     public function join($table, CriteriaInterface $criteria, string $type = ''): self
     {
         $sql = trim(sprintf('%s JOIN %%s ON %%s', strtoupper($type)));
@@ -70,41 +64,31 @@ class SelectQuery extends AbstractQuery
         return $this;
     }
 
-    /**
-     * @param StatementInterface|string $table
-     */
+    /** @param StatementInterface|string $table */
     public function innerJoin($table, CriteriaInterface $criteria): self
     {
         return $this->join($table, $criteria, 'INNER');
     }
 
-    /**
-     * @param StatementInterface|string $table
-     */
+    /** @param StatementInterface|string $table */
     public function leftJoin($table, CriteriaInterface $criteria): self
     {
         return $this->join($table, $criteria, 'LEFT');
     }
 
-    /**
-     * @param StatementInterface|string $table
-     */
+    /** @param StatementInterface|string $table */
     public function rightJoin($table, CriteriaInterface $criteria): self
     {
         return $this->join($table, $criteria, 'RIGHT');
     }
 
-    /**
-     * @param StatementInterface|string $table
-     */
+    /** @param StatementInterface|string $table */
     public function fullJoin($table, CriteriaInterface $criteria): self
     {
         return $this->join($table, $criteria, 'FULL');
     }
 
-    /**
-     * @param mixed ...$columns
-     */
+    /** @param mixed ...$columns */
     public function groupBy(...$columns): self
     {
         $this->groupBy = identifyAll($columns);

--- a/src/Query/UnionQuery.php
+++ b/src/Query/UnionQuery.php
@@ -25,6 +25,7 @@ class UnionQuery extends AbstractQuery
         StatementInterface $right
     ) {
         parent::__construct($engine);
+
         $this->left = $left;
         $this->right = $right;
     }

--- a/src/Query/UpdateQuery.php
+++ b/src/Query/UpdateQuery.php
@@ -21,9 +21,7 @@ class UpdateQuery extends AbstractQuery
     protected ?StatementInterface $table = null;
     protected ?StatementInterface $set = null;
 
-    /**
-     * @param string|StatementInterface $table
-     */
+    /** @param string|StatementInterface $table */
     public function table($table): self
     {
         $this->table = identify($table);

--- a/src/functions.php
+++ b/src/functions.php
@@ -12,25 +12,19 @@ use function sprintf;
 use function strpos;
 use function strtoupper;
 
-/**
- * @param mixed $value
- */
+/** @param mixed $value */
 function isStatement($value): bool
 {
     return $value instanceof StatementInterface;
 }
 
-/**
- * @param mixed $field
- */
+/** @param mixed $field */
 function alias($field, string $alias): ExpressionInterface
 {
     return express('%s AS %s', identify($field), identify($alias));
 }
 
-/**
- * @param mixed ...$replacements
- */
+/** @param mixed ...$replacements */
 function func(string $function, ...$replacements): ExpressionInterface
 {
     $function = sprintf('%s(%%s)', $function);
@@ -38,9 +32,7 @@ function func(string $function, ...$replacements): ExpressionInterface
     return express($function, listing(identifyAll($replacements)));
 }
 
-/**
- * @param mixed $value
- */
+/** @param mixed $value */
 function literal($value): StatementInterface
 {
     return isStatement($value) ? $value : new Partial\Literal($value);
@@ -51,9 +43,7 @@ function on(string $left, string $right): CriteriaInterface
     return criteria('%s = %s', identify($left), identify($right));
 }
 
-/**
- * @param mixed $column
- */
+/** @param mixed $column */
 function order($column, ?string $direction = null): StatementInterface
 {
     if (! $direction) {
@@ -63,9 +53,7 @@ function order($column, ?string $direction = null): StatementInterface
     return express(sprintf('%%s %s', strtoupper($direction)), identify($column));
 }
 
-/**
- * @param mixed ...$replacements
- */
+/** @param mixed ...$replacements */
 function criteria(string $pattern, ...$replacements): CriteriaInterface
 {
     return new Partial\Criteria(express($pattern, ...$replacements));
@@ -76,33 +64,25 @@ function group(CriteriaInterface $criteria): CriteriaInterface
     return criteria('(%s)', $criteria);
 }
 
-/**
- * @param mixed $name
- */
+/** @param mixed $name */
 function field($name): Builder\CriteriaBuilder
 {
     return new Builder\CriteriaBuilder(identify($name));
 }
 
-/**
- * @param mixed $name
- */
+/** @param mixed $name */
 function search($name): Builder\LikeBuilder
 {
     return new Builder\LikeBuilder(identify($name));
 }
 
-/**
- * @param mixed ...$replacements
- */
+/** @param mixed ...$replacements */
 function express(string $pattern, ...$replacements): ExpressionInterface
 {
     return new Partial\Expression($pattern, ...paramAll($replacements));
 }
 
-/**
- * @param mixed $name
- */
+/** @param mixed $name */
 function identify($name): StatementInterface
 {
     if (isStatement($name)) {
@@ -120,17 +100,13 @@ function identify($name): StatementInterface
     return new Partial\Identifier($name);
 }
 
-/**
- * @return StatementInterface[]
- */
+/** @return StatementInterface[] */
 function identifyAll(array $names): array
 {
     return array_map('Latitude\QueryBuilder\identify', $names);
 }
 
-/**
- * @param mixed $value
- */
+/** @param mixed $value */
 function param($value): StatementInterface
 {
     if (isStatement($value)) {
@@ -140,9 +116,7 @@ function param($value): StatementInterface
     return Parameter::create($value);
 }
 
-/**
- * @return StatementInterface[]
- */
+/** @return StatementInterface[] */
 function paramAll(array $values): array
 {
     return array_map('Latitude\QueryBuilder\param', $values);

--- a/tests/Engine/MySqlTest.php
+++ b/tests/Engine/MySqlTest.php
@@ -21,6 +21,10 @@ class MySqlTest extends TestCase
         $field = identify('id');
 
         $this->assertSql('`id`', $field);
+
+        $field = identify('contains`backticks');
+
+        $this->assertSql('`contains``backticks`', $field);
     }
 
     public function testBooleanParameterValue(): void

--- a/tests/Engine/PostgresTest.php
+++ b/tests/Engine/PostgresTest.php
@@ -20,5 +20,9 @@ class PostgresTest extends TestCase
         $field = identify('id');
 
         $this->assertSql('"id"', $field);
+
+        $field = identify('contains"quotes');
+
+        $this->assertSql('"contains""quotes"', $field);
     }
 }

--- a/tests/Engine/SqlServerTest.php
+++ b/tests/Engine/SqlServerTest.php
@@ -21,6 +21,10 @@ class SqlServerTest extends TestCase
         $field = identify('id');
 
         $this->assertSql('[id]', $field);
+
+        $field = identify('contains[brackets]');
+
+        $this->assertSql('[contains[brackets]]]', $field);
     }
 
     public function testLike(): void

--- a/tests/Engine/SqliteTest.php
+++ b/tests/Engine/SqliteTest.php
@@ -21,6 +21,10 @@ class SqliteTest extends TestCase
         $field = identify('id');
 
         $this->assertSql('"id"', $field);
+
+        $field = identify('contains"quotes');
+
+        $this->assertSql('"contains""quotes"', $field);
     }
 
     public function testBooleanParameterValue(): void

--- a/tests/Engine/SqliteTest.php
+++ b/tests/Engine/SqliteTest.php
@@ -20,7 +20,7 @@ class SqliteTest extends TestCase
     {
         $field = identify('id');
 
-        $this->assertSql('id', $field);
+        $this->assertSql('"id"', $field);
     }
 
     public function testBooleanParameterValue(): void
@@ -28,25 +28,25 @@ class SqliteTest extends TestCase
         $criteria = field('active')->eq(true);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertSame('active = 1', $sql);
+        $this->assertSame('"active" = 1', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(false);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertSame('active = 0', $sql);
+        $this->assertSame('"active" = 0', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq(null);
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertSame('active = NULL', $sql);
+        $this->assertSame('"active" = NULL', $sql);
         $this->assertEquals([], $params);
 
         $criteria = field('active')->eq('yes');
         $sql = $criteria->sql($this->engine);
         $params = $criteria->params($this->engine);
-        $this->assertSame('active = ?', $sql);
+        $this->assertSame('"active" = ?', $sql);
         $this->assertEquals(['yes'], $params);
     }
 }

--- a/tests/Issues/ParamsInsideFunctionsTest.php
+++ b/tests/Issues/ParamsInsideFunctionsTest.php
@@ -9,9 +9,7 @@ use Latitude\QueryBuilder\TestCase;
 use function Latitude\QueryBuilder\func;
 use function Latitude\QueryBuilder\param;
 
-/**
- * @link https://github.com/shadowhand/latitude/issues/57
- */
+/** @link https://github.com/shadowhand/latitude/issues/57 */
 class ParamsInsideFunctionsTest extends TestCase
 {
     public function testFuncColumns(): void

--- a/tests/Issues/ResetLimitAndOffsetTest.php
+++ b/tests/Issues/ResetLimitAndOffsetTest.php
@@ -6,9 +6,7 @@ namespace Latitude\QueryBuilder\Issues;
 
 use Latitude\QueryBuilder\TestCase;
 
-/**
- * @link https://github.com/shadowhand/latitude/issues/66
- */
+/** @link https://github.com/shadowhand/latitude/issues/66 */
 class ResetLimitAndOffsetTest extends TestCase
 {
     public function testResetLimit(): void

--- a/tests/Issues/SelectAppendColumnsTest.php
+++ b/tests/Issues/SelectAppendColumnsTest.php
@@ -6,9 +6,7 @@ namespace Latitude\QueryBuilder\Issues;
 
 use Latitude\QueryBuilder\TestCase;
 
-/**
- * @link https://github.com/shadowhand/latitude/issues/58
- */
+/** @link https://github.com/shadowhand/latitude/issues/58 */
 class SelectAppendColumnsTest extends TestCase
 {
     public function testSelectStar(): void

--- a/tests/Issues/SelectAppendTablesTest.php
+++ b/tests/Issues/SelectAppendTablesTest.php
@@ -6,9 +6,7 @@ namespace Latitude\QueryBuilder\Issues;
 
 use Latitude\QueryBuilder\TestCase;
 
-/**
- * @link https://github.com/shadowhand/latitude/issues/58
- */
+/** @link https://github.com/shadowhand/latitude/issues/58 */
 class SelectAppendTablesTest extends TestCase
 {
     public function testSelectTable(): void

--- a/tests/Partial/CriteriaTest.php
+++ b/tests/Partial/CriteriaTest.php
@@ -40,7 +40,7 @@ class CriteriaTest extends TestCase
     public function testInQuery(): void
     {
         $expr = field('country')->in(
-            $this->factory->selectDistinct('country')->from('users')
+            $this->factory->selectDistinct('country')->from('users'),
         );
 
         $this->assertSql('country IN (SELECT DISTINCT country FROM users)', $expr);
@@ -130,7 +130,7 @@ class CriteriaTest extends TestCase
     {
         $expr = group(
             field('username')->eq('jane')
-                ->or(field('first_name')->eq('Jane'))
+                ->or(field('first_name')->eq('Jane')),
         )->and(field('last_login')->isNotNull());
 
         $this->assertSql('(username = ? OR first_name = ?) AND last_login IS NOT NULL', $expr);

--- a/tests/Query/SelectTest.php
+++ b/tests/Query/SelectTest.php
@@ -172,7 +172,7 @@ class SelectTest extends TestCase
     {
         $select = $this->factory
             ->select(
-                alias(func('COUNT', 'id'), 'total')
+                alias(func('COUNT', 'id'), 'total'),
             )
             ->from('employees')
             ->groupBy('department');
@@ -192,7 +192,7 @@ class SelectTest extends TestCase
         $select = $this->factory
             ->select(
                 'department',
-                alias($sum = func('SUM', 'salary'), 'total')
+                alias($sum = func('SUM', 'salary'), 'total'),
             )
             ->from('employees')
             ->groupBy('department')
@@ -226,7 +226,7 @@ class SelectTest extends TestCase
             ->select(
                 'u.id',
                 'u.username',
-                alias(func('COUNT', 'l.id'), 'total')
+                alias(func('COUNT', 'l.id'), 'total'),
             )
             ->from(alias('users', 'u'))
             ->join(alias('logins', 'l'), on('u.id', 'l.user_id'))


### PR DESCRIPTION
The diff on this is larger than in actuality because `phpcbf` needs to be ran.

Merging #162 will clear that up.

I have a field with a backtick in a mysql database (absolutely insane, I know, not my choice) - and found that I was breaking out of the identifier name.

This improves the quoting of of identifiers across the board.

- Common SQL specifies a quote is quoted by doubling the quote, so `a"b` is quoted as `"a""b"`
- MySQL specifies that a single backtick becomes a double backtick, so ```a`b``` is quoted as ``` `a``b` ```
- MS-SQL when using brackets only wants you to quote the closing brackets, so `a[b]` is quoted as `a[b]]]`

I changed Sqlite to target CommonSQL as it matches the behaviour - see: https://www.sqlite.org/lang_keywords.html

More than happy to make any requested changes. Let me know